### PR TITLE
Handle case where project_id is not explicitly set.

### DIFF
--- a/openstack-discovery.py
+++ b/openstack-discovery.py
@@ -82,6 +82,10 @@ class osService:
             stype = stype[:-2]
         stype = stype.replace('-', '_')
         self.stype = stype
+        if "project_id" in conn.auth:
+            prj_id = conn.auth["project_id"]
+        else:
+            prj_id = conn.identity.get_project_id()
         try:
             self.conn = conn.__getattribute__(stype)
             self.conn.service_name = name
@@ -91,7 +95,7 @@ class osService:
                 print("No service proxy of type %s in SDK.\n%s" % (stype, e))
             return
         try:
-            self.ep = self.conn.get_endpoint().replace(conn.auth["project_id"], "${OS_PROJECT_ID}")
+            self.ep = self.conn.get_endpoint().replace(prj_id, "${OS_PROJECT_ID}")
         except Exception as e:
             if stype == "identity":
                 self.ep = conn.auth["auth_url"]


### PR DESCRIPTION
We can auth against openstack with project_name instead (or tokens
or app secrets or ...). Handle this case when replacing endpoints
that encode the project_id.

Signed-off-by: Kurt Garloff <kurt@garloff.de>