### PR TITLE
 Add a minimal GX service offering SD and the latest GX shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ generated SD. Find the examples in `sd` directory and do the validation as follo
 ./sd/validate.py sd/example.jsonld sd/example.ttl
 ```
 
+### GX SelfDescription - Service Offering minimal example
+
+SD definition `sd/gx_service_offering_example.jsonld` should represent
+a minimal GX Service Offering example that is valid against the latest GX shacl shapes `sd/gx_shapes_latest.ttl`.
+The latest GX shacl shapes (at the time of Hackathon#6 23/05/3-4) are
+used by the [GX wizard](https://wizard.lab.gaia-x.eu/), and they have been downloaded from the [GX registry](https://registry.lab.gaia-x.eu/v1/api/trusted-shape-registry/v1/shapes/trustframework).
+
+Try to validate a minimal example against the latest GX shapes (feel free to remove some
+required attribute and check validation result):
+```bash
+./sd/validate.py sd/gx_service_offering_example.jsonld sd/gx_shapes_latest.ttl
+```
+
 ## Status (2022-06-24)
 The current PoC code can discover OpenStack capabilities and produces
 an entry for the services in the service catalogue, with name,

--- a/sd/gx_service_offering_example.jsonld
+++ b/sd/gx_service_offering_example.jsonld
@@ -1,0 +1,65 @@
+{
+  "@context": {
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "gx": "https://https://registry.lab.gaia-x.eu//v1$/gx#",
+    "ex": "http://example.org/"
+  },
+  "@id": "ex:Compute",
+  "@type": "gx:ServiceOffering",
+  "gx:providedBy": {
+    "@id": "did:example:123",
+    "@type": "gx:LegalParticipant",
+    "gx:legalAddress": {
+      "@type": "gx:legalAddress",
+      "gx:countrySubdivisionCode": {
+        "@value": "DE-BE",
+        "@type": "xsd:string"
+      }
+    },
+    "gx:headquarterAddress": {
+      "@type": "gx:legalAddress",
+      "gx:countrySubdivisionCode": {
+        "@value": "DE-BE",
+        "@type": "xsd:string"
+      }
+    },
+    "gx:legalRegistrationNumber": {
+      "@type": "gx:legalRegistrationNumber",
+      "gx:leiCode": {
+        "@value": "123",
+        "@type": "xsd:string"
+      },
+      "gx:vatID": {
+        "@value": "123",
+        "@type": "xsd:string"
+      },
+      "gx:EORI": {
+        "@value": "123",
+        "@type": "xsd:string"
+      },
+      "gx:EUID": {
+        "@value": "123",
+        "@type": "xsd:string"
+      },
+      "gx:taxID": {
+        "@value": "123",
+        "@type": "xsd:string"
+      }
+    }
+  },
+  "gx:policy": "IaaS",
+  "gx:termsAndConditions": {
+    "@type": "gx:SOTermsAndConditions",
+    "gx:URL": {
+      "@value": "https://www.acme.com/compute/tac",
+      "@type": "xsd:string"
+     },
+    "gx:hash": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+  },
+  "gx:dataAccountExport": {
+    "@type": "gx:dataAccountExport",
+    "gx:requestType": "API",
+    "gx:accessType": "digital",
+    "gx:formatType": "application/json"
+  }
+}

--- a/sd/gx_shapes_latest.ttl
+++ b/sd/gx_shapes_latest.ttl
@@ -1,0 +1,191 @@
+@prefix gx: <https://https://registry.lab.gaia-x.eu//v1$/gx#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+gx:ParticipantShape a sh:NodeShape ;
+    sh:targetClass gx:Participant, gx:LegalParticipant ;
+    sh:nodeKind sh:IRI .
+
+# TODO: simplify with https://github.com/zazuko/rdf-validate-shacl/issues/41#issuecomment-745803630
+
+gx:LegalParticipantShape a sh:NodeShape ;
+    sh:targetClass gx:LegalParticipant ;
+    sh:property [
+        sh:path gx:legalRegistrationNumber ;
+        sh:node gx:legalRegistrationNumberShape ;
+        sh:minCount 1 ;
+    ], [
+        sh:path gx:parentOrganization ;
+        sh:node gx:LegalParticipantShape ;
+    ], [
+        sh:path gx:subOrganization ;
+        sh:node gx:LegalParticipantShape ;
+    ], [
+        sh:path gx:headquarterAddress ;
+        sh:minCount 1 ;
+        sh:node gx:PostalAddressShape ;
+    ], [
+        sh:path gx:legalAddress ;
+        sh:minCount 1 ;
+        sh:node gx:PostalAddressShape ;
+    ] .
+
+gx:legalRegistrationNumberShape a sh:NodeShape ;
+    sh:targetClass gx:legalRegistrationNumber ;
+    sh:message "At least one of taxID, vatID, EUID, EORI or leiCode must be defined." ;
+    sh:property [
+        sh:path gx:taxID ;
+        sh:datatype xsd:string ;
+        sh:minLength 3 ;
+    ];
+    sh:property [
+        sh:path gx:EUID ;
+        sh:datatype xsd:string ;
+        sh:minLength 3 ;
+    ];
+    sh:property [
+        sh:path gx:EORI ;
+        sh:datatype xsd:string ;
+        sh:minLength 3 ;
+    ];
+    sh:property [
+        sh:path gx:vatID ;
+        sh:datatype xsd:string ;
+        sh:minLength 3 ;
+    ];
+    sh:property [
+        sh:path gx:leiCode ;
+        sh:datatype xsd:string ;
+        sh:minLength 3 ;
+    ];
+    sh:or (
+        [
+            sh:path gx:taxID ;
+            sh:minCount 1 ;
+        ]
+        [
+            sh:path gx:EUID ;
+            sh:minCount 1 ;
+        ]
+        [
+            sh:path gx:EORI ;
+            sh:minCount 1 ;
+        ]
+        [
+            sh:path gx:vatID ;
+            sh:minCount 1 ;
+        ]
+        [
+            sh:path gx:leiCode ;
+            sh:minCount 1 ;
+        ]
+    ) .
+
+gx:PostalAddressShape a sh:NodeShape ;
+    sh:targetClass gx:headquarterAddress, gx:legalAddress ;
+    sh:property [
+        sh:path gx:countrySubdivisionCode ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:pattern "^[a-zA-Z]{2}-(?:[a-zA-Z]{1,3}|[0-9]{1,3})$" ;
+        sh:flags "i" ;
+        sh:message "an ISO 3166-2 format value is expected." ;
+    ] .
+
+gx:GaiaXTermsAndConditionsShape a sh:NodeShape ;
+    sh:targetClass gx:GaiaXTermsAndConditions;
+    sh:property [
+        sh:path gx:termsAndConditions ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:hasValue '''The PARTICIPANT signing the Self-Description agrees as follows:
+- to update its descriptions about any changes, be it technical, organizational, or legal - especially but not limited to contractual in regards to the indicated attributes present in the descriptions.
+
+The keypair used to sign Verifiable Credentials will be revoked where Gaia-X Association becomes aware of any inaccurate statements in regards to the claims which result in a non-compliance with the Trust Framework and policy rules defined in the Policy Rules and Labelling Document (PRLD).''' ;
+    ] .
+
+gx:DataAccountExportShape
+    a              sh:NodeShape ;
+    sh:targetClass gx:dataAccountExport ;
+    sh:property    [ sh:path     gx:requestType ;
+                     sh:datatype xsd:string ;
+                     sh:name     "Request type" ;
+                     sh:minCount 1 ;
+                     sh:maxCount 1 ;
+                     sh:in       ( "API" "email" "webform" "unregisteredLetter" "registeredLetter" "supportCenter" ) ] ;
+    sh:property    [ sh:path        gx:accessType ;
+                     sh:datatype    xsd:string ;
+                     sh:name        "Access type" ;
+                     sh:minCount    1 ;
+                     sh:maxCount    1 ;
+                     sh:description "type of data support: digital, physical." ;
+                     sh:in          ( "digital" "physical" ) ] ;
+    sh:property    [ sh:path     gx:formatType ;
+                     sh:datatype xsd:string ;
+                     sh:name     "Format type" ;
+                     sh:minCount 1 ;
+                     sh:maxCount 1 ;
+                     sh:pattern  "^\\w+/[-+.\\w]+$" ;
+                     sh:flags    "i" ;
+                     sh:message  "type of Media Types (formerly known as MIME types) as defined by the IANA." ; ] .
+
+gx:SOTermsAndConditionsShape
+    a              sh:NodeShape ;
+    sh:targetClass gx:SOTermsAndConditions ;
+    sh:property    [ sh:path        gx:URL ;
+                     sh:name        "URL" ;
+                     sh:description "a resolvable link to document" ;
+                     sh:minCount    1 ;
+                     sh:maxCount    1 ;
+                     sh:datatype    xsd:string ] ;
+    sh:property    [ sh:path        gx:hash ;
+                     sh:name        "hash" ;
+                     sh:minCount    1 ;
+                     sh:maxCount    1 ;
+                     sh:description "sha256 hash of the above document." ;
+                     sh:datatype    xsd:string ] .
+
+gx:ServiceOfferingShape
+    a              sh:NodeShape ;
+    sh:targetClass gx:ServiceOffering ;
+    sh:property    [ sh:path        gx:providedBy ;
+                     sh:name        "provided by" ;
+                     sh:description "a resolvable link to the participant self-description providing the service." ;
+                     sh:minCount    1 ;
+                     sh:maxCount    1 ;
+                     sh:node gx:LegalParticipantShape ] ; # TODO add alternativePath to support all type of Participant
+    sh:property    [ sh:path     gx:aggregationOf ;
+                     sh:name     "aggregation of" ;
+                     sh:description
+                                 "a resolvable link to the resources self-description related to the service and that can exist independently of it." ;
+                     sh:datatype xsd:string ] ;
+    sh:property    [ sh:path     gx:dependsOn ;
+                     sh:name     "depends on" ;
+                     sh:description
+                                 "a resolvable link to the service offering self-description related to the service and that can exist independently of it." ;
+                     sh:datatype gx:ServiceOffering ] ;
+    sh:property    [ sh:path     gx:termsAndConditions ;
+                     sh:name     "terms & conditions" ;
+                     sh:minCount 1 ;
+                     sh:description
+                                 "a resolvable link to the service offering self-description related to the service and that can exist independently of it." ;
+                     sh:node gx:SOTermsAndConditionsShape ] ;
+    sh:property    [ sh:path     gx:policy ;
+                     sh:name     "policy" ;
+                     sh:minCount 1 ;
+                     sh:description
+                                 "a list of policy expressed using a DSL (e.g., Rego or ODRL) (access control, throttling, usage, retention, …)." ;
+                     sh:datatype xsd:string ] ;
+    sh:property    [ sh:path        gx:dataProtectionRegime ;
+                     sh:name        "data protection regime" ;
+                     sh:description "a list of data protection regime" ;
+                     sh:in          ( "GDPR2016" "LGPD2019" "PDPA2012" "CCPA2018" "VCDPA2021" ) ;
+                     sh:message     "Refer to https://gaia-x.gitlab.io/policy-rules-committee/trust-framework/service_and_subclasses/#service-offering Personal Data Protection Regimes" ;
+                     sh:datatype    xsd:string ] ;
+    sh:property    [ sh:path        gx:dataAccountExport ;
+                     sh:name        "data account export" ;
+                     sh:minCount    1 ;
+                     sh:description "list of methods to export data from your user’s account out of the service" ;
+                     sh:node    gx:DataAccountExportShape ; ] .

--- a/sd/validate.py
+++ b/sd/validate.py
@@ -27,7 +27,7 @@ def validate_sd(sd, schema):
     """Validate SD in jsonld format against given schema in turtle format"""
     conforms, results_graph, results_text = validate(
         load_file(sd),
-        shacl_graph=load_file(schema, file_format="turtle"),
+        shacl_graph=load_file(schema, file_format=SHAPES_FILE_FORMAT),
         data_graph_format=DATA_FILE_FORMAT,
         shacl_graph_format=SHAPES_FILE_FORMAT,
         inference="rdfs",


### PR DESCRIPTION
SD definition `sd/gx_service_offering_example.jsonld` should represent
a minimal GX Service Offering example that is valid against the latest GX shacl shapes `sd/gx_shapes_latest.ttl`.
The latest GX shacl shapes (at the time of Hackathon#6 23/05/3-4) are
used by the [GX wizard](https://wizard.lab.gaia-x.eu/), and they have been downloaded from the [GX registry](https://registry.lab.gaia-x.eu/v1/api/trusted-shape-registry/v1/shapes/trustframework).
