### PR TITLE
Cleanup: No need for double default setting.

### DIFF
--- a/gx-sd-generator.py
+++ b/gx-sd-generator.py
@@ -10,7 +10,6 @@
 SPDX-License-Identifier: EPL-2.0
 """
 
-import os
 import sys
 import getopt
 import importlib
@@ -182,15 +181,7 @@ def main(argv):
     timeout = 12
     mycloud = None
     myk8s = None
-    # Defaults for OpenStack and K8s
-    try:
-        ostack.cloud = os.environ["OS_CLOUD"]
-    except:
-        pass
-    try:
-        k8s.config = os.environ["KUBECONFIG"]
-    except:
-        pass
+    # Defaults for OpenStack and K8s are set by imports
     # Arg parser
     try:
         args: list[str]


### PR DESCRIPTION
Initializaing OpenStack and K8S config environments from the environment variables OS_CLOUD and KUBECONFIG is already done by the imported openstack-discovery.py and k8s-discovery.py respectively. No need (although no harm either) to do it again.